### PR TITLE
Cleanup: Switch to `pull_request_target` to allow `id-token: write`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request:
+  pull_request_target:
     branches: ['main']
   push:
     branches: ['main']
@@ -30,6 +30,11 @@ jobs:
         - '1.2.*'
         - '1.1.*'
         - '1.0.*'
+
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4


### PR DESCRIPTION
:broom: This should let us start experimenting with `cosign_sign` using ambient credentials.

/kind cleanup